### PR TITLE
PG-2279 Remove deprecated pgsm_overflow_target GUC parameter

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -122,22 +122,6 @@ Sets the maximum number of buckets used to generate the histogram output.
 
 Defines the maximum shared memory (in MB) that `pg_stat_monitor` allocates for tracking queries.
 
-### pg_stat_monitor.pgsm_overflow_target (deprecated)
-
-**Default**: on
-
-**Context**: postmaster
-
-Sets the overflow target for `pg_stat_monitor`.
-
-!!! note
-    Starting with version 2.0.0, this option is deprecated. Use the [pg_stat_monitor.pgsm_enable_overflow](#pg_stat_monitorpgsm_enable_overflow) instead.
-
-**Historical defaults:**
-
-- Version 1.0.0 and earlier: `1`
-- Version 1.1.1: `0`
-
 ### pg_stat_monitor.pgsm_track_utility
 
 **Default**: on


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PG-2279

pgsm_overflow_target parameter was deprecated since v2.0, so it's time
to remove it.

Implementation: https://github.com/percona/pg_stat_monitor/pull/637